### PR TITLE
Use HTTP header vs auth in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Usage
 ### Instantiating
 
 ```javascript
-var kudu = require("kudu-api")("website", "$username", "password");
+var kudu = require("kudu-api")({"website": "website", username:"$username", password: "password"});
 ```
 
 ### Source Control `kudu.scm`

--- a/index.js
+++ b/index.js
@@ -12,13 +12,23 @@ var diagnostics = require("./lib/diagnostics");
 var logs = require("./lib/logs");
 var extensions = require("./lib/extensions");
 
-module.exports = function api(website, username, password) {
+module.exports = function api(options) {
+    //options: website, username, password, basic (hashed)
+    var website = options.website,
+        headers = {};
+    if(options.username && options.password){
+        headers.Authorization =  "Basic " +
+            new Buffer(options.username + ":" + options.password)
+            .toString("base64");
+    }
+
+    if(options.basic){
+      headers.Authorization =  "Basic " + options.basic;
+    }
+
     var r = request.defaults({
         baseUrl: "https://" + website + ".scm.azurewebsites.net/",
-        auth: {
-            username: username,
-            password: password
-        }
+        headers: headers,
     });
     return {
         scm: scm(r),

--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -43,6 +43,8 @@ module.exports = function deployment(request) {
             });
         },
         redeploy: function redeploy(id, payoad, cb) {
+          console.log('redeploy called', id , payload, cb);
+
           request.put({
               uri:"/api/deployments/" + id,
               json: payload || {}

--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -47,6 +47,9 @@ module.exports = function deployment(request) {
               uri:"/api/deployments/" + id,
               json: payload || {}
               }, function(err, response, body) {
+                if(!cb){
+                  return;
+                }
                 if (err) return cb(err);
                 cb(null, body, response);
             });

--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -42,7 +42,7 @@ module.exports = function deployment(request) {
                 cb(null, body, response);
             });
         },
-        redeploy: function redeploy(id, payoad, cb) {
+        redeploy: function redeploy(id, payload, cb) {
           console.log('redeploy called', id , payload, cb);
 
           request.put({

--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -42,11 +42,14 @@ module.exports = function deployment(request) {
                 cb(null, body, response);
             });
         },
-        redeploy: function redeploy(id, cb) {
-            request.put("/api/deployments/" + id, function(err, response, body) {
+        redeploy: function redeploy(id, payoad, cb) {
+          request.put({
+              uri:"/api/deployments/" + id,
+              json: data || {}
+              }, function(err, response, body) {
                 if (err) return cb(err);
                 cb(null, body, response);
             });
         }
-    }
+    };
 };

--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -45,7 +45,7 @@ module.exports = function deployment(request) {
         redeploy: function redeploy(id, payoad, cb) {
           request.put({
               uri:"/api/deployments/" + id,
-              json: data || {}
+              json: payload || {}
               }, function(err, response, body) {
                 if (err) return cb(err);
                 cb(null, body, response);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kudu-api",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Node wrapper for the Kudu REST API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kudu-api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Node wrapper for the Kudu REST API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kudu-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Node wrapper for the Kudu REST API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kudu-api",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Node wrapper for the Kudu REST API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kudu-api",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Node wrapper for the Kudu REST API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kudu-api",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Node wrapper for the Kudu REST API",
   "main": "index.js",
   "scripts": {

--- a/test/command.js
+++ b/test/command.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("command", function() {
     it("can execute a command", function(done) {

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -2,7 +2,7 @@ var assert = require("assert");
 var fs = require("fs");
 var path = require("path");
 var exec = require("child_process").exec;
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 var gitUrl1 = "https://github.com/itsananderson/kudu-api-website.git";
 var gitUrl2 = "https://github.com/itsananderson/kudu-api-website.git#1f19ea3b8e68397b6f7c290378526ef37975105d";
@@ -20,7 +20,7 @@ describe("deployment", function() {
                 if (err) done(err);
                 api.deployment.list(function(err, deployments) {
                     if (err) done(err);
-                    deploymentList = deployments; 
+                    deploymentList = deployments;
                     done();
                 });
             });
@@ -78,7 +78,7 @@ describe("deployment", function() {
         api.deployment.log(deploymentList[0].id, function(err, entries) {
             if (err) done(err);
 
-            assert(Array.isArray(entries), "number", "Deployment log entries should be an array"); 
+            assert(Array.isArray(entries), "number", "Deployment log entries should be an array");
             done();
         });
     });

--- a/test/diagnostics.js
+++ b/test/diagnostics.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("diagnostics", function() {
     this.timeout(5000);

--- a/test/dump.js
+++ b/test/dump.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var fs = require("fs");
 var path = require("path");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("dump", function() {
     this.timeout(30 * 1000);

--- a/test/environment-withbasic-credentials.js
+++ b/test/environment-withbasic-credentials.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var api = require("../")(process.env.WEBSITE, process.env.BASIC);
+var api = require("../")({website: process.env.WEBSITE, basic: process.env.BASIC});
 
 describe("environment", function() {
     this.timeout(5000);

--- a/test/environment-withbasic-credentials.js
+++ b/test/environment-withbasic-credentials.js
@@ -1,0 +1,14 @@
+var assert = require("assert");
+var api = require("../")(process.env.WEBSITE, process.env.BASIC);
+
+describe("environment", function() {
+    this.timeout(5000);
+
+    it("can get the environment", function(done) {
+        api.environment.get(function(err, environment) {
+            if (err) done(err);
+            assert.notStrictEqual(environment.version, undefined, "version is defined");
+            done();
+        });
+    });
+});

--- a/test/environment.js
+++ b/test/environment.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("environment", function() {
     this.timeout(5000);

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("extensions", function() {
     this.timeout(5000);

--- a/test/logs.js
+++ b/test/logs.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("logs", function() {
     this.timeout(5000);

--- a/test/scm.js
+++ b/test/scm.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("scm", function() {
     this.timeout(5000);

--- a/test/settings.js
+++ b/test/settings.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("settings", function() {
     this.timeout(5000);

--- a/test/sshkey.js
+++ b/test/sshkey.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var path = require("path");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("sshkey", function() {
     this.timeout(5000);

--- a/test/vfs.js
+++ b/test/vfs.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var path = require("path");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 
 describe("vfs", function() {
     this.timeout(5000);

--- a/test/zip.js
+++ b/test/zip.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var fs = require("fs");
 var path = require("path");
-var api = require("../")(process.env.WEBSITE, process.env.USERNAME, process.env.PASSWORD);
+var api = require("../")({website: process.env.WEBSITE, username: process.env.USERNAME, password: process.env.PASSWORD});
 var exec = require("child_process").exec;
 
 var localZipPath = path.join(__dirname, "test.zip");


### PR DESCRIPTION
Wont be offended if you opt to not use this PR.  But wanted to use header auth vs url auth with these requests.  Its marginally more secure but it does allow people to not save their passwords in the ENV with plain text.  It also opens the door to be able to hash it in a more secure way: 


     "Authorization": "Basic " + new Buffer(key + ":" + secret, "utf8").toString("base64")

I also updated the api to take in a config object vs parameters.  The old way would now be

    api({website: 'websiteaddress', username:'username', password:'password});

if you wanted to use the basic way it would be

    api({website:'websiteaddress', basic:'base64encodedusername:password'})