### PR TITLE
Clean up broken tests and debug logs

### DIFF
--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -43,12 +43,15 @@ module.exports = function deployment(request) {
             });
         },
         redeploy: function redeploy(id, payload, cb) {
-          console.log('redeploy called', id , payload, cb);
+            if (typeof payload === "function") {
+                cb = payload;
+                payload = undefined;
+            }
 
-          request.put({
-              uri:"/api/deployments/" + id,
+            request.put({
+              uri: "/api/deployments/" + id,
               json: payload || {}
-              }, function(err, response, body) {
+              }, function (err, response, body) {
                 if(!cb){
                   return;
                 }

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -11,8 +11,9 @@ module.exports = function diagnostics(request) {
                 if (err) return cb(err);
 
                 if (404 === response.statusCode) {
-                    cb(JSON.parse(body));
+                    return cb(JSON.parse(body));
                 }
+
                 cb(null, JSON.parse(body), response);
             });
         },

--- a/test/command.js
+++ b/test/command.js
@@ -19,8 +19,6 @@ describe("command", function() {
         api.command.exec("echo %CD%", function(err, result) {
             if (err) done(err);
 
-            console.log(result);
-
             assert.equal(result.Error, "", "Error should be empty");
             assert.equal(result.Output, "hello world\r\n", "Output should be 'hello world\\r\\n'");
             assert.equal(result.ExitCode, 0, "Exit code should be 0");

--- a/test/command.js
+++ b/test/command.js
@@ -20,7 +20,7 @@ describe("command", function() {
             if (err) done(err);
 
             assert.equal(result.Error, "", "Error should be empty");
-            assert.equal(result.Output, "hello world\r\n", "Output should be 'hello world\\r\\n'");
+            assert.equal(result.Output, "D:\\home\r\n", "Output should be 'D:\\home\\r\\n'");
             assert.equal(result.ExitCode, 0, "Exit code should be 0");
             done();
         });

--- a/test/environment-withbasic-credentials.js
+++ b/test/environment-withbasic-credentials.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
-var api = require("../")({website: process.env.WEBSITE, basic: process.env.BASIC});
+var basicCredentials = new Buffer(process.env.USERNAME + ":" + process.env.PASSWORD).toString("base64");
+var api = require("../")({ website: process.env.WEBSITE, basic: basicCredentials });
 
 describe("environment", function() {
     this.timeout(5000);

--- a/test/vfs.js
+++ b/test/vfs.js
@@ -13,7 +13,7 @@ describe("vfs", function() {
         api.vfs.getFile("site/wwwroot/test.txt", function(err, content) {
             if (err) done(err);
 
-            assert.equal(content, "test\n", "File content should be 'test\\n'");
+            assert.equal(content.trim(), "test", "Trimmed file content should be 'test'");
             done();
         });
     });


### PR DESCRIPTION
This fixes a handful of broken tests, and removes a number of `console.log` statements from the tests and library code.

It also updates the `BASIC` credentials test to construct the basic credentials from the `USERNAME` and `PASSWORD` fields so that the same environment variables can be used for all tests.