### PR TITLE
JSON handling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,4 +27,4 @@ gulp.task("watch-test", ["test"], function () {
     return gulp.watch(allSources, ["test"]);
 });
 
-gulp.task("watch", ["lint-watch", "test-watch"]);
+gulp.task("watch", ["watch-lint", "watch-test"]);

--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -5,14 +5,22 @@ var utils = require("./utils");
 module.exports = function deployment(request) {
     return {
         list: function list(cb) {
-            request("/api/deployments/", utils.createJsonCallback("listing deployments", cb));
+            var options = {
+                uri: "/api/deployments/",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("listing deployments", cb));
         },
 
         get: function get(id, cb) {
-            var url = "/api/deployments/" + encodeURIComponent(id);
+            var options = {
+                uri: "/api/deployments/" + encodeURIComponent(id),
+                json: true
+            };
             var action = "getting deployment with id " + id;
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         del: function del(id, cb) {
@@ -23,17 +31,23 @@ module.exports = function deployment(request) {
         },
 
         log: function log(id, cb) {
-            var url = "/api/deployments/" + encodeURIComponent(id) + "/log";
+            var options = {
+                uri: "/api/deployments/" + encodeURIComponent(id) + "/log",
+                json: true
+            };
             var action = "listing logs for deployment with id " + id;
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         logDetails: function logDetails(id, entryId, cb) {
-            var url = "/api/deployments/" + encodeURIComponent(id) + "/log/" + encodeURIComponent(entryId);
+            var options = {
+                uri: "/api/deployments/" + encodeURIComponent(id) + "/log/" + encodeURIComponent(entryId),
+                json: true
+            };
             var action = "getting log details with log id " + id + " and entry id " + entryId;
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         deploy: function deploy(repoUrl, cb) {

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -5,14 +5,22 @@ var utils = require("./utils");
 module.exports = function diagnostics(request) {
     return {
         list: function list(cb) {
-            request("/api/diagnostics/settings", utils.createJsonCallback("listing diagnostic settings", cb));
+            var options = {
+                uri: "/api/diagnostics/settings",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("listing diagnostic settings", cb));
         },
 
         get: function get(key, cb) {
-            var url = "/api/diagnostics/settings/" + encodeURIComponent(key);
+            var options = {
+                uri: "/api/diagnostics/settings/" + encodeURIComponent(key),
+                json: true
+            };
             var action = "getting diagnostic settiing with key " + key;
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         del: function del(key, cb) {

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -5,7 +5,12 @@ var utils = require("./utils");
 module.exports = function environment(request) {
     return {
         get: function get(cb) {
-            request("/api/environment", utils.createJsonCallback("getting the Kudu environment", cb));
+            var options = {
+                uri: "/api/environment",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("getting the Kudu environment", cb));
         }
     };
 };

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -6,16 +6,17 @@ module.exports = function extensions(request) {
     function extension(baseUrl) {
         return {
             list: function list(filter, cb) {
+                var query = {};
+
                 if (typeof filter === "function") {
                     cb = filter;
-                    filter = null;
+                } else if (filter) {
+                    query.filter = filter;
                 }
 
-                var query = filter
-                    ? "?filter=" + filter
-                    : "";
                 var options = {
-                    uri: baseUrl + query,
+                    uri: baseUrl,
+                    qs: query,
                     json: true
                 };
                 var action = "listing extensions";

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -14,17 +14,23 @@ module.exports = function extensions(request) {
                 var query = filter
                     ? "?filter=" + filter
                     : "";
-                var url = baseUrl + query;
+                var options = {
+                    uri: baseUrl + query,
+                    json: true
+                };
                 var action = "listing extensions";
 
-                request(url, utils.createJsonCallback(action, cb));
+                request(options, utils.createBodyCallback(action, cb));
             },
 
             get: function get(id, cb) {
-                var url = baseUrl + "/" + encodeURIComponent(id);
+                var options = {
+                    uri: baseUrl + "/" + encodeURIComponent(id),
+                    json: true
+                };
                 var action = "getting extension with id " + id;
 
-                request(url, utils.createJsonCallback(action, cb));
+                request(options, utils.createBodyCallback(action, cb));
             }
         };
     }
@@ -33,10 +39,13 @@ module.exports = function extensions(request) {
     var site = extension("/api/siteextensions");
 
     site.del = function del(id, cb) {
-        var url = "/api/siteextensions/" + encodeURIComponent(id);
+        var options = {
+            uri: "/api/siteextensions/" + encodeURIComponent(id),
+            json: true
+        };
         var action = "deleting extension with id " + id;
 
-        request.del(url, utils.createJsonCallback(action, cb));
+        request.del(options, utils.createBodyCallback(action, cb));
     };
 
     site.set = function set(id, payload, cb) {
@@ -46,7 +55,6 @@ module.exports = function extensions(request) {
         };
         var action = "installing or updating extension with id " + id;
 
-        // Because the request explicitly uses JSON the body will already be parsed
         request.put(options, utils.createBodyCallback(action, cb));
     };
 

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -12,11 +12,12 @@ module.exports = function logs(request) {
 
             var options = {
                 uri: "/api/logs/recent",
-                qs: query
+                qs: query,
+                json: true
             };
             var action = "retrieving application logs";
 
-            request(options, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         }
     };
 };

--- a/lib/scm.js
+++ b/lib/scm.js
@@ -5,7 +5,12 @@ var utils = require("./utils");
 module.exports = function scm(request) {
     return {
         info: function info(cb) {
-            request("/api/scm/info", utils.createJsonCallback("getting information about the repository", cb));
+            var options = {
+                uri: "/api/scm/info",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("getting information about the repository", cb));
         },
 
         clean: function clean(cb) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -5,14 +5,22 @@ var utils = require("./utils");
 module.exports = function settings(request) {
     return {
         list: function list(cb) {
-            request("/api/settings", utils.createJsonCallback("listing settings", cb));
+            var options = {
+                uri: "/api/settings",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("listing settings", cb));
         },
 
         get: function get(key, cb) {
-            var url = "/api/settings/" + encodeURIComponent(key);
+            var options = {
+                uri: "/api/settings/" + encodeURIComponent(key),
+                json: true
+            };
             var action = "getting setting with key " + key;
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         del: function del(key, cb) {

--- a/lib/sshkey.js
+++ b/lib/sshkey.js
@@ -5,16 +5,17 @@ var utils = require("./utils");
 module.exports = function sshkey(request) {
     return {
         get: function get(generate, cb) {
+            var query = {};
+
             if (typeof generate === "function") {
                 cb = generate;
-                generate = false;
+            } else if (generate) {
+                query.ensurePublicKey = 1;
             }
 
-            var query = generate
-                ? "?ensurePublicKey=1"
-                : "";
             var options = {
-                uri: "/api/sshkey/" + query,
+                uri: "/api/sshkey/",
+                qs: query,
                 json: true
             };
             var action = "getting SSH key";

--- a/lib/sshkey.js
+++ b/lib/sshkey.js
@@ -13,10 +13,13 @@ module.exports = function sshkey(request) {
             var query = generate
                 ? "?ensurePublicKey=1"
                 : "";
-            var url = "/api/sshkey/" + query;
+            var options = {
+                uri: "/api/sshkey/" + query,
+                json: true
+            };
             var action = "getting SSH key";
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         }
     };
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,24 +39,7 @@ function createBodyCallback(action, cb) {
     });
 }
 
-function createJsonCallback(action, cb) {
-    return createCallback(action, function (err, response) {
-        if (err) {
-            return cb(err);
-        }
-
-        try {
-            var data = JSON.parse(response.body);
-        } catch (e) {
-            return cb(e);
-        }
-
-        cb(null, data, response);
-    });
-}
-
 module.exports = {
     createCallback: createCallback,
-    createBodyCallback: createBodyCallback,
-    createJsonCallback: createJsonCallback
+    createBodyCallback: createBodyCallback
 };

--- a/lib/vfs.js
+++ b/lib/vfs.js
@@ -23,10 +23,13 @@ module.exports = function vfs(request) {
         listFiles: function listFiles(path, cb) {
             path = ensureTrailingSlash(path);
 
-            var url = "/api/vfs/" + path;
+            var options = {
+                uri: "/api/vfs/" + path,
+                json: true
+            };
             var action = "listing files with path " + path;
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         uploadFile: function uploadFile(localPath, destPath, etag, cb) {

--- a/lib/webjobs.js
+++ b/lib/webjobs.js
@@ -76,16 +76,21 @@ module.exports = function webjobs(request) {
         },
 
         runTriggered: function runTriggered(name, args, cb) {
-            var url = "/api/triggeredwebjobs/" + encodeURIComponent(name) + "/run";
-            var action = "running triggered webjob with name '" + name + "'";
-
+            var query = {};
+            
             if (typeof args === "function") {
                 cb = args;
-            } else if (typeof args === "string") {
-                url += "?arguments=" + encodeURIComponent(args);
+            } else if (args) {
+                query.arguments = args;
             }
 
-            request.post(url, utils.createCallback(action, cb));
+            var options = {
+                url: "/api/triggeredwebjobs/" + encodeURIComponent(name) + "/run",
+                qs: query
+            };
+            var action = "running triggered webjob with name '" + name + "'";
+
+            request.post(options, utils.createCallback(action, cb));
         },
 
         listTriggeredHistory: function listTriggeredHistory(name, cb) {

--- a/lib/webjobs.js
+++ b/lib/webjobs.js
@@ -19,34 +19,53 @@ function createUploadHeaders(localPath) {
 module.exports = function webjobs(request) {
     return {
         listAll: function listAll(cb) {
-            request("/api/webjobs", utils.createJsonCallback("listing all webjobs", cb));
+            var options = {
+                uri: "/api/webjobs",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("listing all webjobs", cb));
         },
 
         listTriggered: function listTriggered(cb) {
-            request("/api/triggeredwebjobs", utils.createJsonCallback("listing triggered webjobs", cb));
+            var options = {
+                uri: "/api/triggeredwebjobs",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("listing triggered webjobs", cb));
         },
 
         listTriggeredAsSwagger: function listTriggeredAsSwagger(cb) {
-            request("/api/triggeredwebjobsswagger", utils.createJsonCallback("listing triggered webjobs as swagger", cb));
+            var options = {
+                uri: "/api/triggeredwebjobsswagger",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("listing triggered webjobs as swagger", cb));
         },
 
         getTriggered: function getTriggered(name, cb) {
-            var url = "/api/triggeredwebjobs/" + encodeURIComponent(name);
+            var options = {
+                uri: "/api/triggeredwebjobs/" + encodeURIComponent(name),
+                json: true
+            };
             var action = "getting triggered webjob with name '" + name + "'";
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         uploadTriggered: function uploadTriggered(name, localPath, cb) {
             var options = {
                 uri: "/api/triggeredwebjobs/" + encodeURIComponent(name),
+                json: true,
                 headers: createUploadHeaders(localPath)
             };
             var action = "uploading triggered webjob with name '" + name + "'";
 
             fs.createReadStream(localPath)
                 .on("error", cb)
-                .pipe(request.put(options, utils.createJsonCallback(action, cb)));
+                .pipe(request.put(options, utils.createBodyCallback(action, cb)));
         },
 
         deleteTriggered: function deleteTriggered(name, cb) {
@@ -70,40 +89,55 @@ module.exports = function webjobs(request) {
         },
 
         listTriggeredHistory: function listTriggeredHistory(name, cb) {
-            var url = "/api/triggeredwebjobs/" + encodeURIComponent(name) + "/history";
+            var options = {
+                uri: "/api/triggeredwebjobs/" + encodeURIComponent(name) + "/history",
+                json: true
+            };
             var action = "listing history for triggered webjob with name '" + name + "'";
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         getTriggeredHistory: function getTriggeredHistory(name, id, cb) {
-            var url = "/api/triggeredwebjobs/" + encodeURIComponent(name) + "/history/" + encodeURIComponent(id);
+            var options = {
+                uri: "/api/triggeredwebjobs/" + encodeURIComponent(name) + "/history/" + encodeURIComponent(id),
+                json: true
+            };
             var action = "getting history for triggered webjob with name '" + name + "' and id '" + id + "'";
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         listContinuous: function listContinuous(cb) {
-            request("/api/continuouswebjobs", utils.createJsonCallback("listing continuous webjobs", cb));
+            var options = {
+                uri: "/api/continuouswebjobs",
+                json: true
+            };
+
+            request(options, utils.createBodyCallback("listing continuous webjobs", cb));
         },
 
         getContinuous: function getContinuous(name, cb) {
-            var url = "/api/continuouswebjobs/" + encodeURIComponent(name);
+            var options = {
+                uri: "/api/continuouswebjobs/" + encodeURIComponent(name),
+                json: true
+            };
             var action = "getting continuous webjob with name '" + name + "'";
 
-            request(url, utils.createJsonCallback(action, cb));
+            request(options, utils.createBodyCallback(action, cb));
         },
 
         uploadContinuous: function uploadContinuous(name, localPath, cb) {
             var options = {
                 uri: "/api/continuouswebjobs/" + encodeURIComponent(name),
+                json: true,
                 headers: createUploadHeaders(localPath)
             };
             var action = "uploading continuous webjob with name '" + name + "'";
 
             fs.createReadStream(localPath)
                 .on("error", cb)
-                .pipe(request.put(options, utils.createJsonCallback(action, cb)));
+                .pipe(request.put(options, utils.createBodyCallback(action, cb)));
         },
 
         deleteContinuous: function deleteContinuous(name, cb) {
@@ -128,17 +162,19 @@ module.exports = function webjobs(request) {
         },
 
         getContinuousSettings: function getContinuousSettings(name, cb) {
-            var url = "/api/continuouswebjobs/" + encodeURIComponent(name) + "/settings";
+            var options = {
+                uri: "/api/continuouswebjobs/" + encodeURIComponent(name) + "/settings",
+                json: true
+            };
             var action = "getting continuous webjob settings with name '" + name + "'";
 
-            request.get(url, utils.createJsonCallback(action, cb));
+            request.get(options, utils.createBodyCallback(action, cb));
         },
 
         setContinuousSettings: function setContinuousSettings(name, settings, cb) {
             var options = {
                 uri: "/api/continuouswebjobs/" + encodeURIComponent(name) + "/settings",
-                body: settings,
-                json: true
+                json: settings
             };
             var action = "setting continuous webjob settings with name '" + name + "'";
 


### PR DESCRIPTION
These changes leverage the `request` module to handle JSON parsing. Query string serialization has also been switched over. The `createJsonCallback` factory has been removed.

All tests passing, seems to work well. One of the steps on the way to 2.0!