### PR TITLE
Adds a option to add a custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var kudu = require("kudu-api")({
     website: "website",
     username: "$username",
     password: "password",
-    domain: "scml.domain.com" //optional
+    domain: "scm.domain.com" //optional
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Usage
 var kudu = require("kudu-api")({
     website: "website",
     username: "$username",
-    password: "password"
+    password: "password",
+    domain: "scml.domain.com" //optional
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -24,11 +24,8 @@ module.exports = function api(options) {
     }
     
     //option: domain - in case the kudu api doesn't run on azurewebsites
-    var toplevelDomain = "scm.azurewebsites.net";
-    if(options.domain){
-        toplevelDomain = options.domain;
-    }
-    
+    var domain = options.domain || "scm.azurewebsites.net";
+
     //options: website, username, password, basic (hashed)
     var website = options.website,
         headers = {};
@@ -44,9 +41,10 @@ module.exports = function api(options) {
     }
 
     var r = request.defaults({
-        baseUrl: "https://" + website + "." + toplevelDomain + "/",
+        baseUrl: "https://" + website + "." + domain + "/",
         headers: headers,
     });
+
     return {
         scm: scm(r),
         command: command(r),

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -67,7 +67,8 @@ function setupKudu(basic, cb) {
             credentials = ensureCredentials(basic, {
                 website: env.WEBSITE,
                 username: env.USERNAME,
-                password: env.PASSWORD
+                password: env.PASSWORD,
+                domain: env.DOMAIN
             });
 
             cb(kuduApi(credentials));


### PR DESCRIPTION
Useful, when the kudu api is accessed on other hosts then azurewebsites. 
This gives developers the option to pass in a domain to the request baseurl. 
If nothing is specified, it will use the azurewebsites domain. 