### PR TITLE
Fix truncated zip downloads

### DIFF
--- a/lib/zip.js
+++ b/lib/zip.js
@@ -9,8 +9,16 @@ module.exports = function zip(request) {
             var url = "/api/zip/" + fromPath;
             var action = "downloading zip file from " + fromPath;
 
-            request(url, utils.createCallback(action, cb))
-                .pipe(fs.createWriteStream(toPath));
+            var callbackWrapper = utils.createCallback(action, cb);
+
+            var response;
+            request(url)
+                .on("response", function(res) {
+                  response = res;
+                })
+                .on("error", err => callbackWrapper(err, response))
+                .pipe(fs.createWriteStream(toPath))
+                .on("close", () => callbackWrapper(null, response));
         },
 
         upload: function upload(fromPath, toPath, cb) {

--- a/test/zip.js
+++ b/test/zip.js
@@ -85,8 +85,14 @@ describe("zip", function () {
     });
 
 
-    it("downloads full zips", function(done) {
+    it("downloads complete zips without truncation", function(done) {
         this.timeout(30 * 1000);
+
+        // The zip download API doesn't report the size of the zip file, so there's no way to verify that the zip
+        // file is the correct size. The best we can do is download several times and verify that the file sizes
+        // are all equal.
+        //
+        // For bug report: https://github.com/itsananderson/kudu-api/issues/21
 
         var downloadSizes = [];
 
@@ -108,6 +114,7 @@ describe("zip", function () {
             });
         }
 
+        // Store downloaded file size. If we've downloaded 5 times, confirm that all the sizes match
         function validateDownload(size) {
             downloadSizes.push(size);
 

--- a/test/zip.js
+++ b/test/zip.js
@@ -84,6 +84,48 @@ describe("zip", function () {
         });
     });
 
+
+    it("downloads full zips", function(done) {
+        this.timeout(30 * 1000);
+
+        var downloadSizes = [];
+
+        function download(cb) {
+            if (fs.existsSync(localZipPath)) {
+                fs.unlinkSync(localZipPath);
+            }
+
+            api.zip.download("site/wwwroot", localZipPath, function(err) {
+              if (err) {
+                  return done(err);
+              }
+
+              fs.exists(localZipPath, function(exists) {
+                  assert(exists, "Local zip should exist after download");
+
+                  cb(fs.statSync(localZipPath).size);
+              });
+            });
+        }
+
+        function validateDownload(size) {
+            downloadSizes.push(size);
+
+            if (downloadSizes.length >= 5) {
+                var firstSize = downloadSizes[0];
+                for (var i = 1; i < downloadSizes.length; i++) {
+                    assert.equal(firstSize, downloadSizes[i]);
+                }
+                done();
+            } else {
+                download(validateDownload);
+            }
+        }
+
+        // Kick off first download
+        download(validateDownload);
+    });
+
     it("should return a not found error downloading a non-existent folder", function (done) {
         api.zip.download("site/wwwroot/does-not-exist", localZipPath, function (err) {
             assert(err, "Error should exist.");


### PR DESCRIPTION
Previously there was a problem where we'd invoke the `zip.download` callback parameter as soon as we received a response from the server, rather than waiting for the file download to complete. This change delays the callback until the download finishes, and adds a test to verify that behavior as best we can.

Fixes #21 